### PR TITLE
fix ecosound-web install failure caused by pip on debian 11

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -14,11 +14,12 @@ RUN apt-get install -y git zip unzip netcat
 RUN docker-php-ext-install pdo_mysql bcmath sockets
 
 RUN composer install --no-plugins --no-scripts --optimize-autoloader --no-dev --no-progress
-RUN apt-get install -y python-dev python-numpy python-setuptools python-pip libsndfile1-dev libasound2-dev imagemagick montage sox lame
+RUN apt-get install -y python && curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py && python get-pip.py && pip install numpy
+
+RUN apt-get install -y python-dev python-setuptools libsndfile1-dev libasound2-dev imagemagick montage sox lame
 RUN chown -R www-data:www-data /var/www/html/sounds /var/www/html/tmp /var/www/html/cache
 RUN chmod +x /var/www/html/bin/svt.py
-RUN pip install scikits.audiolab==0.8
-RUN pip install Pillow
+RUN pip install scikits.audiolab==0.8 Pillow
 
 FROM rabbitmq:3.8.4-rc.3-alpine AS queue
 ENV RABBITMQ_PID_FILE /var/lib/rabbitmq/mnesia/rabbitmq


### PR DESCRIPTION
when I run install.sh to setup ecosound-web last week (Sep22), it failed with message as below:
------
The command '/bin/sh -c apt-get install -y python-dev python-numpy python-setuptools python-pip libsndfile1-dev libasound2-dev imagemagick montage sox lame' returned a non-zero code: 100
Service 'queue' failed to build : Build failed
------
After analysis, the root cause comes from unsupporting python-pip install by package manager. That's why dockerfile is updated.