### PR TITLE
Fix DataTables 'All' option for server-side processing

### DIFF
--- a/src/src/BioSounds/Provider/CollectionProvider.php
+++ b/src/src/BioSounds/Provider/CollectionProvider.php
@@ -335,15 +335,22 @@ class CollectionProvider extends AbstractProvider
             $sql .= " AND CONCAT(IFNULL(c.collection_id,''), IFNULL(c.name,''), IFNULL(u.name,''), IFNULL(c.doi,''), IFNULL(c.sphere,''), IFNULL(c.note,''), IFNULL(c.creation_date,''), IFNULL(c.view,'')) LIKE :search ";
         }
         $a = ['', 'c.collection_id', 'c.name', 'u.name', 'c.doi', 'c.sphere', 'c.note', 'c.creation_date', 'c.view', 'c.public_access', 'c.public_tags'];
-        $sql .= " ORDER BY $a[$column] $dir LIMIT :length OFFSET :start";
+        $sql .= " ORDER BY $a[$column] $dir";
+        // Only add LIMIT if length is not -1 (DataTables "All" option sends -1)
+        if ($length != '-1') {
+            $sql .= " LIMIT :length OFFSET :start";
+        }
         $this->database->prepareQuery($sql);
         $params = [
             ':project_id' => $projectId,
             ':user_id' => Auth::getUserID(),
             ':user_id1' => Auth::getUserID(),
-            ':length' => $length,
-            ':start' => $start,
         ];
+        // Only add pagination params if not showing all
+        if ($length != '-1') {
+            $params[':length'] = $length;
+            $params[':start'] = $start;
+        }
         if ($search) {
             $params[':search'] = '%' . $search . '%';
         }

--- a/src/src/BioSounds/Provider/IndexLogProvider.php
+++ b/src/src/BioSounds/Provider/IndexLogProvider.php
@@ -104,10 +104,7 @@ class IndexLogProvider extends AbstractProvider
             LEFT JOIN recording r ON r.recording_id = i.recording_id
             LEFT JOIN `user` u ON u.user_id = i.user_id
             LEFT JOIN index_type it ON it.index_id = i.index_id ";
-        $params = [
-            ':length' => $length,
-            ':start' => $start,
-        ];
+        $params = [];
         if (!Auth::isUserAdmin()) {
             $sql = $sql . ' WHERE i.user_id = :user_id ';
             $params[':user_id'] = Auth::getUserLoggedID();
@@ -117,7 +114,13 @@ class IndexLogProvider extends AbstractProvider
             $sql .= " CONCAT(IFNULL(i.log_id,''), IFNULL(r.name,''), IFNULL(u.name,''), IFNULL(it.name,''), IFNULL(i.min_time,''), IFNULL(i.max_time,''), IFNULL(i.min_frequency,''), IFNULL(i.max_frequency,''), IFNULL(i.variable_type,''), IFNULL(i.variable_order,''), IFNULL(i.variable_name,''), IFNULL(i.variable_value,''), IFNULL(i.creation_date,''), IFNULL(i.version,'')) LIKE :search ";
         }
         $a = ['', 'i.log_id', 'r.name', 'u.name', 'it.name', 'i.version', 'i.min_time', 'i.max_time', 'i.min_frequency', 'i.max_frequency', 'i.variable_type', 'i.variable_order', 'i.variable_name', 'i.variable_value', 'i.creation_date'];
-        $sql .= " ORDER BY $a[$column] $dir LIMIT :length OFFSET :start ";
+        $sql .= " ORDER BY $a[$column] $dir";
+        // Only add LIMIT if length is not -1 (DataTables "All" option sends -1)
+        if ($length != '-1') {
+            $sql .= " LIMIT :length OFFSET :start";
+            $params[':length'] = $length;
+            $params[':start'] = $start;
+        }
         $this->database->prepareQuery($sql);
         if ($search) {
             $params[':search'] = '%' . $search . '%';

--- a/src/src/BioSounds/Provider/RecordingProvider.php
+++ b/src/src/BioSounds/Provider/RecordingProvider.php
@@ -436,12 +436,14 @@ class RecordingProvider extends AbstractProvider
             'file_date',       // 21: Date
             'file_time'        // 22: Time
         ];
-		$sql .= " ORDER BY $a[$column] $dir LIMIT :length OFFSET :start";
+        $sql .= " ORDER BY $a[$column] $dir";
+        // Only add LIMIT if length is not -1 (DataTables "All" option sends -1)
+        if ($length != '-1') {
+            $sql .= " LIMIT :length OFFSET :start";
+        }
         $this->database->prepareQuery($sql);
         $params = [
             ':collectionId' => $collectionId,
-            ':length' => $length,
-            ':start' => $start,
         ];
         if ($search) {
             $params[':search'] = '%' . $search . '%';

--- a/src/src/BioSounds/Provider/SiteProvider.php
+++ b/src/src/BioSounds/Provider/SiteProvider.php
@@ -110,7 +110,11 @@ class SiteProvider extends AbstractProvider
         }
         $sql .= " GROUP BY s.site_id ";
         $a = ['', 's.site_id', 's.name', 's.longitude_WGS84_dd_dddd', 's.latitude_WGS84_dd_dddd', 's.topography_m', 's.freshwater_depth_m', 's.gadm0', 's.gadm1', 's.gadm2', 'e1.name', 'e2.name', 'e3.name'];
-        $sql .= " ORDER BY $a[$column] $dir LIMIT $length OFFSET $start";
+        $sql .= " ORDER BY $a[$column] $dir";
+        // Only add LIMIT if length is not -1 (DataTables "All" option sends -1)
+        if ($length != '-1') {
+            $sql .= " LIMIT $length OFFSET $start";
+        }
         $this->database->prepareQuery($sql);
         $result = $this->database->executeSelect();
         $iho = (new SiteProvider())->getIHO();

--- a/src/src/BioSounds/Provider/TagProvider.php
+++ b/src/src/BioSounds/Provider/TagProvider.php
@@ -362,7 +362,11 @@ class TagProvider extends AbstractProvider
         }
         $sql .= " GROUP BY t.tag_id";
         $a = ['', 't.tag_id', 'sound.soundscape_component', 'sound.sound_type', 'r.name', 'u.name', 't.creator_type', 't.confidence', 't.min_time', 't.max_time', 't.min_freq', 't.max_freq', 's.binomial', 't.uncertain', 't.sound_distance_m', 't.distance_not_estimable', 't.individuals', 'st.name', 'reference_call', 't.comments', 't.creation_date'];
-        $sql .= " ORDER BY $a[$column] $dir LIMIT $length OFFSET $start";
+        $sql .= " ORDER BY $a[$column] $dir";
+        // Only add LIMIT if length is not -1 (DataTables "All" option sends -1)
+        if ($length != '-1') {
+            $sql .= " LIMIT $length OFFSET $start";
+        }
         $this->database->prepareQuery($sql);
         $result = $this->database->executeSelect();
         $soundscape_components = (new SoundProvider())->get();

--- a/src/src/BioSounds/Provider/TagReviewProvider.php
+++ b/src/src/BioSounds/Provider/TagReviewProvider.php
@@ -70,7 +70,11 @@ class TagReviewProvider extends AbstractProvider
             $sql .= " AND CONCAT(IFNULL(tr.tag_id,''), IFNULL(r.`name`,''), IFNULL(u.`name`,''), IFNULL(trs.`name`,''), IFNULL(s.binomial,''), IFNULL(tr.note,'')) LIKE '%$search%' ";
         }
         $a = ['', 't.tag_id', 'r.`name`', 'u.`name`', 'trs.`name`', 's.binomial', 'tr.note'];
-        $sql .= " ORDER BY $a[$column] $dir LIMIT $length OFFSET $start";
+        $sql .= " ORDER BY $a[$column] $dir";
+        // Only add LIMIT if length is not -1 (DataTables "All" option sends -1)
+        if ($length != '-1') {
+            $sql .= " LIMIT $length OFFSET $start";
+        }
         $this->database->prepareQuery($sql);
         $result = $this->database->executeSelect();
         $status = $this->getStatus();


### PR DESCRIPTION
- Handle length=-1 by conditionally omitting LIMIT clause in SQL queries
- Fixed in 6 Provider classes: Tag, Recording, Site, TagReview, IndexLog, Collection
- Allows users to view all records when selecting 'All' from the dropdown
- For prepared statements: only add :length/:start params when length != '-1'
- For string interpolation: conditionally append LIMIT clause
- coded with Claude, tested locally