### PR TITLE
Fix continuous playback UI and functionality

### DIFF
--- a/src/templates/recording/player/js/playbackRate.js
+++ b/src/templates/recording/player/js/playbackRate.js
@@ -116,6 +116,8 @@ playbackControl.oninput = function () {
         seek = 0;
     }
     playbackValue.innerHTML = this.value;
+    // Update all instances of playback rate value display
+    $('.playback-rate-value').text(parseFloat(this.value).toFixed(1));
 };
 
 $('#playerCursor').draggable({

--- a/src/templates/recording/player/js/player.js
+++ b/src/templates/recording/player/js/player.js
@@ -27,8 +27,17 @@ continuousPlaySelector.change(function () {
 });
 
 $('#continue-playback').click(function () {
-    $(this).toggleClass('active');
-    $('#btn-playback').click()
+    let isActive = $(this).hasClass('active');
+    let newValue = isActive ? '0' : '1';
+    
+    setContinuousPlay(!isActive);
+    
+    // If enabling continuous play, ensure we have next segment buffered
+    if (!isActive && maxTime < fileDuration.toFixed(1)) {
+        let nextStart = maxTime;
+        let nextEnd = Math.min(nextStart + selectionDuration, fileDuration.toFixed(1));
+        preloadNextSegment(nextStart, nextEnd);
+    }
 })
 
 $('#stop').click(function () {
@@ -239,16 +248,6 @@ let setContinuousPlay = function (value) {
 
 window.continuousPlay = continuousPlay;
 window.setContinuousPlay = setContinuousPlay;
-
-$('#play-dropdown').click(function (event) {
-    event.stopPropagation();
-    $('#dropdown-menu-play').slideToggle();
-    $(this).find('i').toggleClass('fa-caret-down fa-caret-up');
-});
-
-$('#dropdown-menu-play').click(function (event) {
-    event.stopPropagation();
-});
 
 $(document).on('audioPlaybackStarted', function () {
     if (isContinuous && window.audioBufferQueue.length === 0 && maxTime < fileDuration.toFixed(1)) {

--- a/src/templates/recording/player/player.html.twig
+++ b/src/templates/recording/player/player.html.twig
@@ -11,19 +11,17 @@
                 <button id="play" class="btn btn-link btn-sm" data-playing="false" role="switch" aria-checked="false" title="Space for play/pause">
                     <i class="fas fa-play"></i>
                 </button>
-                <div class="dropdown" id="play-dropdown">
-                    <button id="dropdown" class="btn btn-link text-dark" style="padding: 0" data-playing="false" role="switch" aria-checked="false" data-toggle="dropdown">
-                        <i class="fa-solid fa-caret-down" style="font-size: 12px"></i>
+                <button id="continue-playback" class="btn btn-link btn-sm {{ player.isContinuousPlay ? 'active':'' }}" title="Continue playback beyond current frame">
+                    <i class="continue-playback"></i>
+                </button>
+                <div class="dropdown" id="speed-dropdown" style="display: inline-block;">
+                    <button id="speed-toggle" class="btn btn-link btn-sm text-dark" title="Playback speed" data-toggle="dropdown">
+                        <span class="playback-rate-value">1.0</span>x
                     </button>
-                    <div class="dropdown-menu" id="dropdown-menu-play" style="min-width: 180px">
-                        <button id="continue-playback" class="btn btn-link {{ player.isContinuousPlay ? 'active':'' }}" title="Continue playback beyond current frame">
-                            <i class="continue-playback"></i> Continuous
-                        </button>
-                        <div class="dropdown-divider"></div>
+                    <div class="dropdown-menu" id="dropdown-menu-speed" style="min-width: 180px; padding: 10px;">
                         <div class="playback-slider-container">
-                            <label for="playback-rate" style="font-size: 0.8rem; margin-bottom: 4px;">Playback Speed</label>
+                            <label for="playback-rate" style="font-size: 0.8rem; margin-bottom: 4px; display: block;">Playback Speed</label>
                             <input id="playback-rate" class="custom-range js-playback-rate-control" type="range" min="0.05" max="1" step="0.01" value="1" style="width: 100%;">
-                            <label for="playback-rate" style="text-align: center;"><span class="playback-rate-value">1.0</span>x</label>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
- Move continuous playback button inline next to play button (remove dropdown)
- Replace confusing caret-down icon with expandable speed control (1.0x button)
- Fix critical bug: continuous playback button was clicking non-existent #btn-playback element
- Now properly calls setContinuousPlay() and preloads next segment when enabled
- Update playback rate display to sync across all instances (button + slider label)
- Remove old dropdown toggle JavaScript that's no longer needed

This resolves the visibility issue where continuous playback and speed controls were hidden in a dropdown, and fixes the broken continuous playback functionality where the player wasn't automatically advancing to the next frame after playback ended.